### PR TITLE
Fix spelling mistake: MongoResource instead of MongoResources

### DIFF
--- a/docs/basic-concept.md
+++ b/docs/basic-concept.md
@@ -10,12 +10,12 @@ Each service provides a _Resource_ class which can be use to interact with it. U
 public class AccountRepositoryTests
     : IClassFixture<MongoResource>
 {
-    private readonly MongoResources _mongoResources;
+    private readonly MongoResource _mongoResource;
 
     public AccountRepositoryTests(
-        MongoResources mongoResources)
+        MongoResource mongoResource)
     {
-        _mongoResources = mongoResources;
+        _mongoResource = mongoResource;
     }
 }
 ```

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -121,15 +121,15 @@ dotnet add package Squadron.Mongo
           },
           {
             title: "2. Access",
-            content: `Inject the MongoResources into your test class constructor:
+            content: `Inject the MongoResource into your test class constructor:
 \`\`\`csharp
 public class AccountRepositoryTests
     : IClassFixture<MongoResource>
 {
-    private readonly MongoResources _mongoResource;
+    private readonly MongoResource _mongoResource;
 
     public AccountRepositoryTests(
-        MongoResources mongoResource)
+        MongoResource mongoResource)
     {
         _mongoResource = mongoResource;
     }
@@ -139,7 +139,7 @@ public class AccountRepositoryTests
           },
           {
             title: "3. Use",
-            content: `In your test use MongoResources to create a database and initialize your repository:
+            content: `In your test use MongoResource to create a database and initialize your repository:
 \`\`\`csharp
 [Fact]
 public void CreateAccount_AccountExists()


### PR DESCRIPTION
The first example on the squadron docs page contains a spelling mistakes: "MongoResources" instead of "MongoResource".
With the extra "s" the example does not compile. 
I replaced all occurrences of "MongoResources" with "MongoResources" in the docs repository.